### PR TITLE
RAND-362 - Rename variable as it clashed with keyword

### DIFF
--- a/groups/infrastructure/locals.tf
+++ b/groups/infrastructure/locals.tf
@@ -26,7 +26,7 @@ locals {
     Environment = var.environment
     StackName   = local.stack_name
     Terraform   = true
-    Version     = var.version
+    Version     = var.dependency_track_aws_terraform_version
     Repository  = "companieshouse/dependency-track-aws-terraform"
     Group       = "infrastructure"
   }

--- a/groups/infrastructure/variables.tf
+++ b/groups/infrastructure/variables.tf
@@ -13,7 +13,7 @@ variable "db_username" {
 variable "enable_deletion_protection" {
   type = bool
 }
-variable "version" {
+variable "dependency_track_aws_terraform_version" {
   type = string
   default = "0.1.0"
 }


### PR DESCRIPTION
* version is not a valid variable name therefore renamed to reference the repository, thus making it clearer
