### PR TITLE
RAND-307 - Work around sensitive issue with Terraform module

### DIFF
--- a/groups/api/ecs_secrets.tf
+++ b/groups/api/ecs_secrets.tf
@@ -6,6 +6,6 @@ module "server-ecs-secrets" {
 
   environment = var.environment
   name_prefix = "${local.service_name}-${var.environment}"
-  secrets     = local.application_secrets
+  secrets     = local.parameter_store_secrets
   kms_key_id  = data.aws_kms_key.kms_key.id
 }

--- a/groups/api/locals.tf
+++ b/groups/api/locals.tf
@@ -25,6 +25,13 @@ locals {
 
   health_check_grace_period_seconds = 60 * 60 # 1 hour
 
+  parameter_store_secrets = {
+    "oidc-client-id": local.application_secrets["oidc-client-id"],
+    "oidc-issuer": local.application_secrets["oidc-issuer"],
+    "oidc-username-claim": local.application_secrets["oidc-username-claim"],
+    "oidc-teams-claim": local.application_secrets["oidc-teams-claim"],
+  }
+
   # create a map of secret name => secret arn to pass into ecs service module
   # using the trimprefix function to remove the prefixed path from the secret name
   secrets_arn_map = {

--- a/groups/frontend/ecs_secrets.tf
+++ b/groups/frontend/ecs_secrets.tf
@@ -6,6 +6,6 @@ module "frontend-ecs-secrets" {
 
   environment = var.environment
   name_prefix = "${local.service_name}-${var.environment}"
-  secrets     = local.application_secrets
+  secrets     = local.parameter_store_secrets
   kms_key_id  = data.aws_kms_key.kms_key.id
 }

--- a/groups/frontend/locals.tf
+++ b/groups/frontend/locals.tf
@@ -24,6 +24,11 @@ locals {
 
   health_check_grace_period_seconds = 60 * 60 # 1 hour
 
+  parameter_store_secrets = {
+    "oidc-client-id": local.application_secrets["oidc-client-id"]
+    "oidc-issuer": local.application_secrets["oidc-issuer"]
+  }
+
   # create a map of secret name => secret arn to pass into ecs service module
   # using the trimprefix function to remove the prefixed path from the secret name
   secrets_arn_map = {


### PR DESCRIPTION
Works around the following error:

> ```shell
> Error: Invalid for_each argument
> │ 
> │   on .terraform/modules/server-ecs-secrets/aws/ecs/secrets/parameters.tf line 2, in resource "aws_ssm_parameter" "secret_parameters":
> │    2:   for_each    = var.secrets
> │     ├────────────────
> │     │ var.secrets has a sensitive value
> │ 
> │ Sensitive values, or values derived from sensitive values, cannot be used as for_each arguments. If used, the sensitive value could be exposed as a resource instance key.
> ╵
> Error: Terraform command exited with exit code: 1
> ```