### PR TITLE
Increase resources to proxy side car

### DIFF
--- a/groups/api/locals.tf
+++ b/groups/api/locals.tf
@@ -83,8 +83,8 @@ locals {
     docker_registry = "dependencytrack-apiserver"
   }
   sidecar_requirements = {
-    cpu    = 0.5 * local.cpu_memory_unit
-    memory = local.cpu_memory_unit
+    cpu    = local.cpu_memory_unit
+    memory = 2 * local.cpu_memory_unit
   }
   task_definition_requirements = {
     cpu    = 8 * local.cpu_memory_unit


### PR DESCRIPTION
* ELB healthcheck calls `/health` on the proxy sidecar container. Observing the logs there are healthchecks every minute or so suggesting that the interval '300' is not being observed which suggests that the response times are too slow (since there is a 5s timeout)